### PR TITLE
Restyle interface with AlgorithmVisualizer-inspired theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,24 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: light;
-}
-
 html {
   scroll-behavior: smooth;
 }
 
 body {
-  @apply bg-gray-50 text-gray-900 antialiased;
+  @apply min-h-screen bg-[radial-gradient(circle_at_top,_rgba(0,187,249,0.08),_transparent_55%),radial-gradient(circle_at_bottom,_rgba(247,37,133,0.08),_transparent_60%)] bg-brand-dark text-slate-100 antialiased;
 }
 
 a {
-  @apply text-brand;
+  @apply text-brand-light transition hover:text-brand;
 }
 
 button:focus-visible,
 input:focus-visible,
 textarea:focus-visible {
-  @apply outline-none ring-2 ring-brand/60 ring-offset-2;
+  @apply outline-none ring-2 ring-brand-light/70 ring-offset-2 ring-offset-surface-elevated;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,14 +105,14 @@ export default function HomePage() {
             <div className="space-y-4">
               <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
                 <div>
-                  <h2 className="text-2xl font-semibold text-gray-900">Highlights</h2>
+                  <h2 className="text-2xl font-semibold text-white">Highlights</h2>
                   {source ? (
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-slate-400">
                       Source: {source.type === "file" ? source.name ?? "Uploaded file" : source.url}
                     </p>
                   ) : null}
                 </div>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-slate-400">
                   {source?.type === "file"
                     ? "Playback buttons use your uploaded file."
                     : "Playback buttons use the original URL."}
@@ -121,9 +121,9 @@ export default function HomePage() {
               <ClipsGrid clips={clips} masterSrc={masterSrc} />
             </div>
           ) : (
-            <div className="rounded-3xl border border-dashed border-gray-200 bg-white p-12 text-center text-gray-600">
-              <p className="text-lg font-semibold text-gray-800">No highlights detected.</p>
-              <p className="mt-2 text-sm">Try another video or adjust your source.</p>
+            <div className="rounded-3xl border border-dashed border-surface-border/80 bg-surface-highlight/70 p-12 text-center text-slate-300">
+              <p className="text-lg font-semibold text-white">No highlights detected.</p>
+              <p className="mt-2 text-sm text-slate-400">Try another video or adjust your source.</p>
             </div>
           )
         ) : null}

--- a/src/components/ClipCard.tsx
+++ b/src/components/ClipCard.tsx
@@ -78,8 +78,8 @@ export default function ClipCard({ clip, masterSrc }: ClipCardProps) {
   };
 
   return (
-    <article className="flex h-full flex-col rounded-3xl bg-white p-5 shadow-sm ring-1 ring-gray-100 transition hover:-translate-y-1 hover:shadow-md">
-      <div className="relative overflow-hidden rounded-2xl bg-gray-100">
+    <article className="flex h-full flex-col rounded-3xl border border-surface-border/70 bg-surface-elevated/95 p-5 shadow-card transition hover:-translate-y-1 hover:border-brand-light/50 hover:shadow-[0_30px_65px_-35px_rgba(0,245,212,0.5)]">
+      <div className="relative overflow-hidden rounded-2xl bg-surface-highlight/60">
         {clip.thumbnailUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img src={clip.thumbnailUrl} alt={clip.title} className="h-48 w-full object-cover" />
@@ -91,20 +91,20 @@ export default function ClipCard({ clip, masterSrc }: ClipCardProps) {
             className="h-48 w-full rounded-2xl object-cover"
           />
         ) : (
-          <div className="flex h-48 w-full items-center justify-center bg-gradient-to-br from-brand/10 via-white to-brand/10 text-sm font-medium text-brand">
+          <div className="flex h-48 w-full items-center justify-center bg-gradient-to-br from-brand/20 via-transparent to-brand-light/20 text-sm font-medium text-brand-light">
             Clip preview
           </div>
         )}
-        <span className="absolute left-3 top-3 inline-flex items-center rounded-full bg-black/65 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+        <span className="absolute left-3 top-3 inline-flex items-center rounded-full bg-black/70 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-white">
           {formatTimestamp(clip.startSec)} – {formatTimestamp(clip.endSec)}
         </span>
       </div>
       <div className="mt-4 flex flex-1 flex-col gap-4">
         <div className="space-y-2">
-          <h3 className="line-clamp-2 text-lg font-semibold text-gray-900">{clip.title}</h3>
-          <ul className="flex flex-wrap gap-2 text-sm text-brand">
+          <h3 className="line-clamp-2 text-lg font-semibold text-white">{clip.title}</h3>
+          <ul className="flex flex-wrap gap-2 text-sm text-brand-light">
             {clip.hashtags.map((tag) => (
-              <li key={tag} className="rounded-full bg-brand/10 px-2.5 py-1 font-medium">
+              <li key={tag} className="rounded-full bg-brand-light/15 px-2.5 py-1 font-medium">
                 {tag.startsWith("#") ? tag : `#${tag}`}
               </li>
             ))}
@@ -115,7 +115,7 @@ export default function ClipCard({ clip, masterSrc }: ClipCardProps) {
             <button
               type="button"
               onClick={handlePlay}
-              className="inline-flex items-center gap-2 rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand/90"
+              className="inline-flex items-center gap-2 rounded-full bg-brand px-4 py-2 text-sm font-semibold text-brand-dark shadow-sm transition hover:bg-brand-light focus-visible:ring-2 focus-visible:ring-brand-light/80 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-elevated"
             >
               <PlayIcon className="h-4 w-4" aria-hidden="true" />
               {isPlaying ? "Playing" : "Play clip"}
@@ -123,7 +123,7 @@ export default function ClipCard({ clip, masterSrc }: ClipCardProps) {
             <button
               type="button"
               onClick={handleReplay}
-              className="inline-flex items-center gap-2 rounded-full border border-brand/40 px-4 py-2 text-sm font-semibold text-brand transition hover:border-brand hover:text-brand"
+              className="inline-flex items-center gap-2 rounded-full border border-brand-light/60 px-4 py-2 text-sm font-semibold text-brand-light transition hover:border-brand-light hover:text-white"
             >
               <ArrowPathIcon className="h-4 w-4" aria-hidden="true" />
               Replay

--- a/src/components/ClipsGrid.tsx
+++ b/src/components/ClipsGrid.tsx
@@ -9,9 +9,9 @@ type ClipsGridProps = {
 export default function ClipsGrid({ clips, masterSrc }: ClipsGridProps) {
   if (clips.length === 0) {
     return (
-      <div className="rounded-3xl border border-dashed border-gray-200 bg-white p-12 text-center text-gray-600">
-        <p className="text-lg font-semibold text-gray-800">No highlights detected.</p>
-        <p className="mt-2 text-sm">Try another video or tweak your source.</p>
+      <div className="rounded-3xl border border-dashed border-surface-border/80 bg-surface-highlight/70 p-12 text-center text-slate-300">
+        <p className="text-lg font-semibold text-white">No highlights detected.</p>
+        <p className="mt-2 text-sm text-slate-400">Try another video or tweak your source.</p>
       </div>
     );
   }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,8 +3,6 @@
 import { ArrowDownIcon } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
 
-const gradients = "bg-gradient-to-br from-brand to-brand-light";
-
 export default function Hero() {
   const handleClick = () => {
     const el = document.getElementById("upload");
@@ -14,34 +12,32 @@ export default function Hero() {
   return (
     <section
       className={clsx(
-        "relative overflow-hidden rounded-3xl px-6 py-24 text-center text-white shadow-card",
-        gradients,
+        "relative overflow-hidden rounded-3xl border border-surface-border/80 bg-surface-elevated/95 px-6 py-24 text-center text-slate-100 shadow-card",
         "mx-auto max-w-5xl"
       )}
     >
+      <div className="absolute inset-0 -z-10 bg-hero-radial opacity-80" aria-hidden="true" />
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-brand/25 via-transparent to-brand-light/20" aria-hidden="true" />
       <div className="mx-auto flex max-w-3xl flex-col items-center gap-8">
         <div className="space-y-4">
-          <p className="inline-flex items-center rounded-full bg-white/15 px-4 py-1 text-sm font-medium uppercase tracking-wide">
+          <p className="inline-flex items-center rounded-full border border-brand-light/40 bg-brand-light/15 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-light">
             New · AI-powered highlights
           </p>
-          <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">
+          <h1 className="text-4xl font-semibold leading-tight text-white drop-shadow-[0_8px_35px_rgba(0,245,212,0.25)] sm:text-5xl">
             Turn any video into shareable highlights
           </h1>
-          <p className="text-lg text-white/85 sm:text-xl">
+          <p className="text-lg text-slate-200 sm:text-xl">
             Upload a file or paste a link. Let AI find the moments that matter.
           </p>
         </div>
         <button
           type="button"
           onClick={handleClick}
-          className="group inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-base font-semibold text-brand transition hover:translate-y-0.5 hover:bg-white/90 focus-visible:ring-offset-brand"
+          className="group inline-flex items-center gap-2 rounded-full bg-brand-light px-6 py-3 text-base font-semibold text-brand-dark transition hover:translate-y-0.5 hover:bg-brand focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
         >
           Get started
           <ArrowDownIcon className="h-5 w-5 transition-transform group-hover:translate-y-0.5" aria-hidden="true" />
         </button>
-      </div>
-      <div className="pointer-events-none absolute inset-0 -z-10 opacity-40" aria-hidden="true">
-        <div className="absolute left-1/2 top-1/2 h-[480px] w-[480px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-white blur-3xl" />
       </div>
     </section>
   );

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -4,12 +4,12 @@ type ProgressProps = {
 
 export default function Progress({ message = "Analyzing with Puter…" }: ProgressProps) {
   return (
-    <div className="flex items-center justify-center gap-3 rounded-2xl border border-dashed border-brand/40 bg-white/70 px-6 py-5 text-brand">
+    <div className="flex items-center justify-center gap-3 rounded-2xl border border-dashed border-brand-light/50 bg-surface-highlight/70 px-6 py-5 text-brand-light">
       <span
         className="inline-flex h-4 w-4 animate-spin rounded-full border-[3px] border-current border-t-transparent"
         aria-hidden="true"
       />
-      <span className="font-medium" role="status">
+      <span className="font-medium text-slate-100" role="status">
         {message}
       </span>
     </div>

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -105,10 +105,13 @@ export default function Uploader({ onAnalyze, analyzing, error }: UploaderProps)
   const hasSelection = !!file || !!url;
 
   return (
-    <section id="upload" className="mx-auto max-w-4xl space-y-8 rounded-3xl bg-white p-8 shadow-sm">
+    <section
+      id="upload"
+      className="mx-auto max-w-4xl space-y-8 rounded-3xl border border-surface-border/70 bg-surface-elevated/90 p-8 shadow-card backdrop-blur"
+    >
       <header className="space-y-3 text-center">
-        <h2 className="text-3xl font-semibold text-gray-900">Upload or paste a link</h2>
-        <p className="text-base text-gray-600">AI highlights in seconds. Analysis may take longer for long videos.</p>
+        <h2 className="text-3xl font-semibold text-white">Upload or paste a link</h2>
+        <p className="text-base text-slate-300">AI highlights in seconds. Analysis may take longer for long videos.</p>
       </header>
       <form className="space-y-6" onSubmit={handleSubmit} noValidate>
         <label
@@ -117,7 +120,9 @@ export default function Uploader({ onAnalyze, analyzing, error }: UploaderProps)
           onDrop={handleDrop}
           className={clsx(
             "flex cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed px-6 py-10 text-center transition",
-            file ? "border-brand bg-brand/5" : "border-gray-300 hover:border-brand/70 hover:bg-brand/5"
+            file
+              ? "border-brand-light/70 bg-brand-light/10"
+              : "border-surface-border hover:border-brand-light/70 hover:bg-surface-highlight/60"
           )}
         >
           <input
@@ -129,14 +134,14 @@ export default function Uploader({ onAnalyze, analyzing, error }: UploaderProps)
             className="sr-only"
             onChange={handleFileChange}
           />
-          <span className="rounded-full bg-brand/10 px-3 py-1 text-sm font-medium text-brand">Drag & drop</span>
-          <p className="text-base font-semibold text-gray-900">Drop your video here, or click to browse</p>
-          <p className="text-sm text-gray-500">Supported formats: MP4, WebM, OGG, MOV, MKV</p>
-          {file ? <p className="text-sm text-brand">Selected: {file.name}</p> : null}
+          <span className="rounded-full bg-brand-light/15 px-3 py-1 text-sm font-medium text-brand-light">Drag & drop</span>
+          <p className="text-base font-semibold text-white">Drop your video here, or click to browse</p>
+          <p className="text-sm text-slate-400">Supported formats: MP4, WebM, OGG, MOV, MKV</p>
+          {file ? <p className="text-sm text-brand-light">Selected: {file.name}</p> : null}
         </label>
 
         <div className="space-y-2">
-          <label htmlFor="videoUrl" className="block text-sm font-medium text-gray-700">
+          <label htmlFor="videoUrl" className="block text-sm font-medium text-slate-200">
             Or paste a video URL
           </label>
           <input
@@ -146,13 +151,13 @@ export default function Uploader({ onAnalyze, analyzing, error }: UploaderProps)
             placeholder="https://example.com/video.mp4"
             value={url}
             onChange={handleUrlChange}
-            className="w-full rounded-xl border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 shadow-sm transition focus:border-brand"
+            className="w-full rounded-xl border border-surface-border/80 bg-surface-highlight/70 px-4 py-3 text-base text-slate-100 shadow-sm transition focus:border-brand-light focus:outline-none"
           />
-          {urlError ? <p className="text-sm text-rose-600" role="alert">{urlError}</p> : null}
+          {urlError ? <p className="text-sm text-rose-400" role="alert">{urlError}</p> : null}
         </div>
 
         {error ? (
-          <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700" role="alert">
+          <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200" role="alert">
             {error}
           </div>
         ) : null}
@@ -161,11 +166,11 @@ export default function Uploader({ onAnalyze, analyzing, error }: UploaderProps)
           <button
             type="submit"
             disabled={!hasSelection || analyzing}
-            className="inline-flex items-center justify-center rounded-full bg-brand px-6 py-3 text-base font-semibold text-white shadow-sm transition disabled:cursor-not-allowed disabled:bg-brand/50"
+            className="inline-flex items-center justify-center rounded-full bg-brand px-6 py-3 text-base font-semibold text-brand-dark shadow-sm transition hover:bg-brand-light focus-visible:ring-2 focus-visible:ring-brand-light focus-visible:ring-offset-2 focus-visible:ring-offset-surface-elevated disabled:cursor-not-allowed disabled:bg-brand/40 disabled:text-brand-dark/60"
           >
             {analyzing ? "Analyzing…" : "Analyze"}
           </button>
-          <p className="text-sm text-gray-500">Your media stays on this device in mock mode.</p>
+          <p className="text-sm text-slate-400">Your media stays on this device in mock mode.</p>
         </div>
       </form>
     </section>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,12 +10,24 @@ const config: Config = {
     extend: {
       colors: {
         brand: {
-          DEFAULT: "#6366f1",
-          light: "#a855f7"
+          DEFAULT: "#00f5d4",
+          light: "#00bbf9",
+          accent: "#f72585",
+          dark: "#080b1b"
+        },
+        surface: {
+          DEFAULT: "#0d1226",
+          elevated: "#161b3a",
+          highlight: "#1f2651",
+          border: "#2c356a"
         }
       },
       boxShadow: {
-        card: "0 20px 45px -15px rgba(99, 102, 241, 0.35)"
+        card: "0 30px 60px -25px rgba(0, 187, 249, 0.45)"
+      },
+      backgroundImage: {
+        "hero-radial":
+          "radial-gradient(circle at 15% 20%, rgba(0, 245, 212, 0.25), transparent 55%), radial-gradient(circle at 85% 0%, rgba(247, 37, 133, 0.25), transparent 45%)"
       }
     }
   },


### PR DESCRIPTION
## Summary
- replace the default light palette with an AlgorithmVisualizer-inspired neon gradient theme
- refresh hero, uploader, progress, and clip cards to use the new surface and accent colors across the UI
- introduce Tailwind design tokens for brand and surface colors plus a hero background effect

## Testing
- npm run lint *(fails: next not found because dependencies cannot be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d87e2014688321add3a400d21f6cf8