### PR TITLE
Integrate Puter analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Set `NEXT_PUBLIC_MOCK=1` to use the built-in fake Puter.js responses.
 NEXT_PUBLIC_MOCK=1 npm run dev
 ```
 
+## Puter integration
+
+To use the live Puter pipeline, configure the Smartclip frontend with your Puter endpoint and (optionally) credentials:
+
+```bash
+# .env.local
+NEXT_PUBLIC_PUTER_ANALYZE_URL="https://api.puter.com/v1/apps/<app-id>/analyze"
+NEXT_PUBLIC_PUTER_APP_ID="<app-id>"             # optional header, if required by your Puter app
+NEXT_PUBLIC_PUTER_API_KEY="<public-api-key>"    # optional bearer token for authenticated requests
+NEXT_PUBLIC_PUTER_MAX_CLIPS=6                   # optional override for maximum clips requested
+```
+
+Restart the dev server after updating environment variables. If you don't yet have a Puter endpoint, enable `NEXT_PUBLIC_MOCK=1` to stay in demo mode.
+
 ## Project structure
 
 - `src/app` – App Router pages and layout.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/src/lib/puter.ts
+++ b/src/lib/puter.ts
@@ -35,6 +35,113 @@ const mockResponse: Clip[] = [
 ];
 
 const MOCK_ENABLED = process.env.NEXT_PUBLIC_MOCK === "1";
+const ANALYZE_URL = process.env.NEXT_PUBLIC_PUTER_ANALYZE_URL;
+const API_KEY = process.env.NEXT_PUBLIC_PUTER_API_KEY;
+const APP_ID = process.env.NEXT_PUBLIC_PUTER_APP_ID;
+const MAX_CLIPS = Number.parseInt(process.env.NEXT_PUBLIC_PUTER_MAX_CLIPS ?? "6", 10);
+
+type RawClip = {
+  id?: string;
+  title?: string;
+  start?: number | string;
+  end?: number | string;
+  startSec?: number | string;
+  endSec?: number | string;
+  startSeconds?: number | string;
+  endSeconds?: number | string;
+  startMs?: number | string;
+  endMs?: number | string;
+  startMilliseconds?: number | string;
+  endMilliseconds?: number | string;
+  duration?: number | string;
+  hashtags?: string[];
+  tags?: string[];
+  thumbnailUrl?: string;
+  thumbnail_url?: string;
+  preview?: { url?: string };
+  playback?: { url?: string };
+  playbackUrl?: string;
+  playback_url?: string;
+};
+
+function coerceSeconds(...values: Array<number | string | undefined>): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number.parseFloat(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function coerceMilliseconds(...values: Array<number | string | undefined>): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number.parseFloat(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function normalizeRawClip(raw: RawClip, index: number): Clip {
+  const startMs = coerceMilliseconds(raw.startMs, raw.startMilliseconds);
+  const endMs = coerceMilliseconds(raw.endMs, raw.endMilliseconds);
+
+  const startSec = coerceSeconds(
+    raw.startSec,
+    raw.startSeconds,
+    raw.start,
+    typeof startMs === "number" ? startMs / 1000 : undefined
+  );
+  const endSec = coerceSeconds(
+    raw.endSec,
+    raw.endSeconds,
+    raw.end,
+    typeof endMs === "number" ? endMs / 1000 : undefined,
+    typeof startSec === "number" && typeof raw.duration !== "undefined"
+      ? startSec + Number(raw.duration)
+      : undefined
+  );
+
+  if (typeof startSec !== "number" || !Number.isFinite(startSec)) {
+    throw new Error(`Puter response clip #${index + 1} is missing a valid start time.`);
+  }
+
+  if (typeof endSec !== "number" || !Number.isFinite(endSec)) {
+    throw new Error(`Puter response clip #${index + 1} is missing a valid end time.`);
+  }
+
+  const title = raw.title?.toString().trim();
+  if (!title) {
+    throw new Error(`Puter response clip #${index + 1} is missing a title.`);
+  }
+
+  const hashtags = Array.isArray(raw.hashtags) ? raw.hashtags : Array.isArray(raw.tags) ? raw.tags : [];
+
+  const thumbnailUrl = raw.thumbnailUrl ?? raw.thumbnail_url ?? raw.preview?.url;
+  const playbackUrl = raw.playbackUrl ?? raw.playback_url ?? raw.playback?.url;
+
+  return {
+    id: raw.id ?? `clip-${index}`,
+    title,
+    startSec,
+    endSec,
+    hashtags,
+    thumbnailUrl,
+    playbackUrl
+  };
+}
 
 export async function analyzeVideo(input: AnalyzeInput): Promise<Clip[]> {
   if (!input.file && !input.url) {
@@ -46,7 +153,87 @@ export async function analyzeVideo(input: AnalyzeInput): Promise<Clip[]> {
     return mockResponse;
   }
 
-  // Placeholder for future Puter.js integration.
-  // This throws to make it clear the real integration is pending.
-  throw new Error("Puter.js integration not yet configured. Set NEXT_PUBLIC_MOCK=1 for demo mode.");
+  if (!ANALYZE_URL) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_PUTER_ANALYZE_URL. Provide your Puter analyze endpoint or enable NEXT_PUBLIC_MOCK=1."
+    );
+  }
+
+  if (typeof window === "undefined") {
+    throw new Error("Video analysis must be triggered from the browser environment.");
+  }
+
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (API_KEY) {
+    headers["Authorization"] = `Bearer ${API_KEY}`;
+  }
+  if (APP_ID) {
+    headers["X-Puter-App-Id"] = APP_ID;
+  }
+
+  const body = new FormData();
+  if (input.file) {
+    body.append("file", input.file);
+  }
+  if (input.url) {
+    body.append("url", input.url);
+  }
+  if (Number.isFinite(MAX_CLIPS) && MAX_CLIPS > 0) {
+    body.append("max_clips", String(MAX_CLIPS));
+  }
+
+  const response = await fetch(ANALYZE_URL, {
+    method: "POST",
+    headers,
+    body,
+    cache: "no-store"
+  });
+
+  if (!response.ok) {
+    let message = `Puter request failed with status ${response.status}`;
+    try {
+      const errorData = await response.json();
+      const details = errorData?.message ?? errorData?.error ?? JSON.stringify(errorData);
+      if (details) {
+        message = `${message}: ${details}`;
+      }
+    } catch (error) {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new Error("Puter response was not valid JSON.");
+  }
+
+  const rawClips = Array.isArray(payload)
+    ? payload
+    : Array.isArray((payload as { clips?: unknown }).clips)
+      ? (payload as { clips: unknown[] }).clips
+      : Array.isArray((payload as { highlights?: unknown }).highlights)
+        ? (payload as { highlights: unknown[] }).highlights
+        : undefined;
+
+  if (!rawClips) {
+    throw new Error("Puter response did not include any clips.");
+  }
+
+  const normalized: Clip[] = [];
+  rawClips.forEach((item, index) => {
+    try {
+      normalized.push(normalizeRawClip(item as RawClip, index));
+    } catch (error) {
+      console.warn(error);
+    }
+  });
+
+  if (normalized.length === 0) {
+    throw new Error("Puter did not return any usable clips. Try another video or check your integration.");
+  }
+
+  return normalized;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -15,9 +19,25 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- replace the mock-only Puter helper with a real fetch call that posts uploads/URLs to a configurable Puter analyze endpoint
- normalise various Puter clip response shapes, support optional API key/app headers, and surface richer error handling when responses fail
- document the required environment variables for the live pipeline and align TypeScript config with the Next.js lint suggestions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d87f6e3a5c8321a8a21b3fc5f7c5f1